### PR TITLE
Release tus-js-client version with correct build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skynetlabs/tus-js-client",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A pure JavaScript client for the tus resumable upload protocol",
   "publishConfig": {
     "access": "public"
@@ -104,6 +104,7 @@
     "test-node": "jasmine test/spec/node-index.js",
     "test-types": "tsd",
     "test": "./bin/test && npm run test-types",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prepublishOnly": "yarn && yarn build"
   }
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Not exactly sure how it happened, but v2.4.0 was released with a test build
which included some debug statements in the console. I added a prepublishOnly
script to prevent this from happening again.